### PR TITLE
v3全8回をv2デザインに統一

### DIFF
--- a/materials/v3/session-01.html
+++ b/materials/v3/session-01.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">9</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:11%"></div></div>
 <div class="wrap">
 
 <!-- Slide 1: オープニング -->
@@ -358,7 +368,7 @@ AIは知らないことも「それっぽく」答えてしまうことがあり
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);
 document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};

--- a/materials/v3/session-02.html
+++ b/materials/v3/session-02.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">7</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:14%"></div></div>
 <div class="wrap">
 
 <div class="slide on"><div class="inner">
@@ -174,7 +184,7 @@ li strong,p strong{color:#1e293b}
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);
 document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};

--- a/materials/v3/session-03.html
+++ b/materials/v3/session-03.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">7</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:14%"></div></div>
 <div class="wrap">
 
 <div class="slide on"><div class="inner">
@@ -176,7 +186,7 @@ li strong,p strong{color:#1e293b}
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};
 document.getElementById('notesBtn').onclick=()=>{document.getElementById('notes').classList.toggle('on');document.getElementById('notesBtn').classList.toggle('on')};

--- a/materials/v3/session-04.html
+++ b/materials/v3/session-04.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">7</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:14%"></div></div>
 <div class="wrap">
 
 <div class="slide on"><div class="inner">
@@ -172,7 +182,7 @@ B：（具体的に）
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};
 document.getElementById('notesBtn').onclick=()=>{document.getElementById('notes').classList.toggle('on');document.getElementById('notesBtn').classList.toggle('on')};

--- a/materials/v3/session-05.html
+++ b/materials/v3/session-05.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">7</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:14%"></div></div>
 <div class="wrap">
 
 <div class="slide on"><div class="inner">
@@ -164,7 +174,7 @@ li strong,p strong{color:#1e293b}
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};
 document.getElementById('notesBtn').onclick=()=>{document.getElementById('notes').classList.toggle('on');document.getElementById('notesBtn').classList.toggle('on')};

--- a/materials/v3/session-06.html
+++ b/materials/v3/session-06.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">7</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:14%"></div></div>
 <div class="wrap">
 
 <div class="slide on"><div class="inner">
@@ -168,7 +178,7 @@ li strong,p strong{color:#1e293b}
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};
 document.getElementById('notesBtn').onclick=()=>{document.getElementById('notes').classList.toggle('on');document.getElementById('notesBtn').classList.toggle('on')};

--- a/materials/v3/session-07.html
+++ b/materials/v3/session-07.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">7</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:14%"></div></div>
 <div class="wrap">
 
 <div class="slide on"><div class="inner">
@@ -180,7 +190,7 @@ li strong,p strong{color:#1e293b}
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};
 document.getElementById('notesBtn').onclick=()=>{document.getElementById('notes').classList.toggle('on');document.getElementById('notesBtn').classList.toggle('on')};

--- a/materials/v3/session-08.html
+++ b/materials/v3/session-08.html
@@ -7,62 +7,71 @@
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{height:100%;overflow:hidden}
-body{font-family:'Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#fafafa;color:#1e293b;line-height:1.7;-webkit-font-smoothing:antialiased}
-.bar{position:fixed;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:rgba(255,255,255,.96);border-bottom:1px solid #e2e8f0;font-size:13px;z-index:10}
+body{font-family:'Segoe UI','Hiragino Kaku Gothic ProN','Noto Sans JP','Meiryo',sans-serif;background:#f8f9fb;color:#1e293b;line-height:1.7}
+.bar{position:fixed;top:0;left:0;right:0;height:44px;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;background:rgba(255,255,255,.95);border-bottom:1px solid #e2e8f0;font-size:13px;backdrop-filter:blur(8px);z-index:100}
 .bar a{color:#64748b;text-decoration:none}.bar a:hover{color:#1e293b}
 .bar .session{color:#3b82f6;font-weight:600}
-.bar .timer{font-variant-numeric:tabular-nums;color:#64748b}
-.bar .timer button{margin-left:6px;padding:2px 8px;border:1px solid #cbd5e1;background:#fff;border-radius:4px;cursor:pointer;font-size:11px;color:#64748b}
-.bar .count{color:#94a3b8;font-size:12px}
-.wrap{position:fixed;top:40px;bottom:0;left:0;right:0;overflow:hidden}
-.slide{position:absolute;inset:0;padding:56px 80px;overflow-y:auto;opacity:0;transition:opacity .25s;pointer-events:none}
-.slide.on{opacity:1;pointer-events:auto}
-.slide .inner{max-width:840px;margin:0 auto}
-.tag{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:#64748b;letter-spacing:2px;margin-bottom:18px;font-weight:600}
-.tag .dot{width:6px;height:6px;border-radius:50%;background:#3b82f6}
-.dur{margin-left:auto;padding:2px 8px;background:#f1f5f9;color:#64748b;border-radius:4px;font-size:11px;letter-spacing:0;font-weight:500}
-h1{font-size:46px;font-weight:700;margin-bottom:28px;color:#1e293b;line-height:1.2;letter-spacing:-.5px}
-h2{font-size:22px;font-weight:700;margin:32px 0 14px;color:#1e293b}
-h3{font-size:17px;font-weight:600;margin:22px 0 10px;color:#334155}
-.lead{font-size:18px;color:#475569;margin-bottom:18px;line-height:1.6}
-p{font-size:16px;color:#475569;margin-bottom:10px}
-ul,ol{font-size:16px;padding-left:24px;color:#475569;margin-bottom:12px}
-li{margin-bottom:5px}
+.bar .timer{font-variant-numeric:tabular-nums;color:#1e293b;font-size:16px;font-weight:600}
+.bar .timer button{margin-left:8px;padding:3px 10px;border:1px solid #cbd5e1;background:transparent;border-radius:5px;cursor:pointer;font-size:12px;color:#1e293b;transition:background .2s}
+.bar .timer button:hover{background:#f1f5f9}
+.bar .count{color:#64748b;font-size:12px}
+.progress-bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:#e2e8f0;z-index:100}
+.progress-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#8b5cf6);transition:width .3s ease}
+.wrap{position:fixed;top:44px;bottom:3px;left:0;right:0;overflow:hidden}
+.slide{position:absolute;top:0;left:0;right:0;bottom:0;overflow-y:auto;overflow-x:hidden;padding:60px 72px 80px;opacity:0;transform:translateX(50px);transition:opacity .35s ease,transform .35s ease;pointer-events:none;scroll-behavior:smooth}
+.slide.on{opacity:1;transform:translateX(0);pointer-events:auto}
+.slide.prev{transform:translateX(-50px)}
+.slide .inner{max-width:960px;margin:0 auto}
+.tag{display:inline-flex;align-items:center;gap:10px;font-size:14px;color:#64748b;letter-spacing:3px;text-transform:uppercase;margin-bottom:22px;font-weight:600}
+.tag .dot{width:8px;height:8px;border-radius:50%;background:#3b82f6}
+.dur{margin-left:auto;padding:4px 12px;background:#f1f5f9;color:#64748b;border-radius:6px;font-size:13px;letter-spacing:0;font-weight:500;text-transform:none}
+h1{font-size:56px;font-weight:700;margin-bottom:24px;background:linear-gradient(135deg,#2563eb,#7c3aed);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.25}
+h2{font-size:40px;font-weight:700;margin:60px 0 20px;color:#1e293b}
+h3{font-size:28px;font-weight:600;margin:36px 0 14px;color:#334155}
+.lead{font-size:26px;color:#475569;margin-bottom:24px;line-height:1.65}
+p{font-size:24px;color:#475569;margin-bottom:16px}
+ul,ol{font-size:22px;padding-left:36px;color:#475569;margin-bottom:18px}
+li{margin-bottom:10px}
 li strong,p strong{color:#1e293b}
-.box{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;margin:12px 0;font-size:15px;color:#475569;line-height:1.65}
-.box.accent{border-left:4px solid #3b82f6}
-.box.warn{border-left:4px solid #fbbf24;background:#fffbeb}
-.box.danger{border-left:4px solid #f87171;background:#fef2f2}
+.box{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:22px 28px;margin:18px 0;font-size:22px;color:#475569;line-height:1.7}
+.box.accent{border-left:6px solid #3b82f6}
+.box.warn{border-color:#fbbf24;background:#fffbeb}
+.box.danger{border-color:#f87171;background:#fef2f2}
 .box.calm{background:#f8fafc;border-color:#f1f5f9}
-.box.success{border-left:4px solid #22c55e;background:#f0fdf4}
-.try{background:#fff;border:1px dashed #94a3b8;border-radius:10px;padding:16px 20px 16px 20px;margin:12px 0;font-size:14px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;position:relative;white-space:pre-wrap;line-height:1.65}
-.cp{position:absolute;top:8px;right:8px;padding:4px 10px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:11px;border-radius:4px;font-family:inherit}
+.box.success{border-color:#86efac;background:#f0fdf4}
+.try{position:relative;background:#fff;border:1px solid #e2e8f0;border-left:6px solid #22c55e;border-radius:12px;padding:20px 24px;margin:18px 0;font-size:20px;color:#1e293b;font-family:ui-monospace,'Hiragino Kaku Gothic ProN',monospace;white-space:pre-wrap;line-height:1.7;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.cp{position:absolute;top:10px;right:10px;padding:6px 14px;border:1px solid #cbd5e1;background:#f8fafc;color:#64748b;cursor:pointer;font-size:13px;border-radius:6px;font-family:inherit;transition:all .2s}
+.cp:hover{background:#dcfce7;border-color:#22c55e;color:#16a34a}
 .cp.done{background:#dcfce7;border-color:#22c55e;color:#16a34a}
-.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:18px 0}
-.toc-item{display:flex;align-items:center;gap:12px;padding:10px 14px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:14px;color:#475569}
-.toc-item .n{font-weight:700;color:#3b82f6;min-width:18px;text-align:right;font-variant-numeric:tabular-nums}
+.toc{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin:24px 0}
+.toc-item{display:flex;align-items:center;gap:16px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:20px;color:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.toc-item .n{min-width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
 .toc-item .t{flex:1}
-.toc-item .m{font-size:11px;color:#94a3b8;font-variant-numeric:tabular-nums}
-.steps{display:flex;flex-direction:column;gap:8px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:#fff;border:1px solid #e2e8f0;border-radius:8px;font-size:15px;color:#475569}
-.step .n{min-width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0;margin-top:2px}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin:12px 0}
-.card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px;font-size:14px}
-.card h4{font-size:15px;margin-bottom:4px;color:#1e293b;font-weight:600}
-.card p{font-size:13px;margin:0 0 6px;color:#64748b}
-.card a{color:#3b82f6;font-size:12px;text-decoration:none}
+.toc-item .m{font-size:14px;color:#94a3b8;font-variant-numeric:tabular-nums}
+.steps{display:flex;flex-direction:column;gap:14px;margin:20px 0}
+.step{display:flex;align-items:center;gap:18px;padding:18px 22px;background:#fff;border:1px solid #e2e8f0;border-radius:14px;font-size:22px;color:#1e293b}
+.step .n{min-width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;background:#eff6ff;color:#2563eb;flex-shrink:0}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px;margin:20px 0}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:26px;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.card h4{font-size:22px;margin-bottom:8px;color:#1e293b;font-weight:600}
+.card p{font-size:18px;margin:0 0 10px;color:#64748b}
+.card a{color:#3b82f6;font-size:16px;text-decoration:none;font-weight:500}
 .card a:hover{text-decoration:underline}
-.goal{display:inline-block;padding:8px 14px;background:#eff6ff;border-radius:8px;color:#2563eb;font-size:15px;font-weight:500;margin-top:8px}
-.cta{display:block;padding:20px 24px;background:#3b82f6;color:#fff;border-radius:12px;text-decoration:none;font-size:18px;font-weight:600;margin:18px 0;text-align:center;transition:background .2s}
-.cta:hover{background:#2563eb}
-.cta-note{font-size:13px;color:#94a3b8;text-align:center;margin-top:-8px;margin-bottom:18px}
-.nav{position:fixed;top:50%;width:40px;height:40px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:18px;display:flex;align-items:center;justify-content:center;transform:translateY(-50%);z-index:5}
-.nav:hover{background:#f1f5f9;color:#1e293b}.nav.l{left:14px}.nav.r{right:14px}.nav:disabled{opacity:.2;cursor:default}
-.notes{position:fixed;left:16px;right:16px;bottom:10px;background:rgba(255,255,255,.98);border:1px solid #e2e8f0;border-radius:8px;padding:12px 16px;font-size:13px;color:#475569;line-height:1.55;transform:translateY(140%);transition:transform .25s;max-height:160px;overflow-y:auto;z-index:9}
-.notes.on{transform:translateY(0)}.notes strong{color:#d97706}
-.notesBtn{position:fixed;right:14px;bottom:12px;width:32px;height:32px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#94a3b8;cursor:pointer;font-size:13px;z-index:10}
-.notesBtn.on{background:#fffbeb;color:#d97706;border-color:#fbbf24}
-@media(max-width:700px){.slide{padding:32px 22px}h1{font-size:30px}h2{font-size:18px}h3{font-size:15px}p,ul,ol,.box,.try,.step,.lead{font-size:14px}.toc{grid-template-columns:1fr}}
+.goal{display:inline-block;padding:14px 22px;background:#eff6ff;border-radius:12px;color:#2563eb;font-size:22px;font-weight:600;margin-top:14px}
+.cta{display:block;padding:24px 32px;background:linear-gradient(135deg,#3b82f6,#7c3aed);color:#fff;border-radius:14px;text-decoration:none;font-size:24px;font-weight:600;margin:22px 0;text-align:center;transition:all .2s;box-shadow:0 4px 12px rgba(59,130,246,.25)}
+.cta:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(59,130,246,.35)}
+.cta-note{font-size:16px;color:#94a3b8;text-align:center;margin-top:-10px;margin-bottom:22px}
+.nav{position:fixed;top:50%;z-index:50;width:52px;height:52px;border-radius:50%;background:rgba(255,255,255,.9);border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:26px;display:flex;align-items:center;justify-content:center;transition:all .2s;transform:translateY(-50%);box-shadow:0 2px 6px rgba(0,0,0,.06)}
+.nav:hover{background:#f1f5f9;color:#1e293b}
+.nav.l{left:18px}.nav.r{right:18px}
+.nav:disabled{opacity:.2;cursor:default}
+.notes{position:fixed;bottom:6px;left:20px;right:20px;z-index:90;background:rgba(255,255,255,.97);border:1px solid #e2e8f0;border-radius:10px;padding:14px 18px;font-size:15px;color:#475569;line-height:1.55;backdrop-filter:blur(8px);transform:translateY(calc(100% + 12px));transition:transform .3s ease;max-height:160px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.notes.on{transform:translateY(0)}
+.notes strong{color:#d97706}
+.notesBtn{position:fixed;bottom:12px;right:20px;z-index:91;width:38px;height:38px;border-radius:50%;background:#fff;border:1px solid #e2e8f0;color:#64748b;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;transition:all .2s;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.notesBtn:hover{background:#f1f5f9;color:#1e293b}
+.notesBtn.on{background:#fffbeb;border-color:#f59e0b;color:#d97706}
+@media(max-width:768px){.slide{padding:40px 28px 60px}h1{font-size:36px}h2{font-size:28px}h3{font-size:22px}p,ul,ol,.lead,.box,.try,.step,.toc-item{font-size:17px}.toc{grid-template-columns:1fr}.cards{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -71,6 +80,7 @@ li strong,p strong{color:#1e293b}
   <div class="timer"><span id="elapsed">00:00</span><button id="tBtn">▶</button></div>
   <div class="count"><span id="cur">1</span>/<span id="tot">7</span></div>
 </div>
+<div class="progress-bar"><div class="progress-fill" id="pfill" style="width:14%"></div></div>
 <div class="wrap">
 
 <div class="slide on"><div class="inner">
@@ -179,7 +189,7 @@ li strong,p strong{color:#1e293b}
 <script>
 const slides=document.querySelectorAll('.slide');const total=slides.length;document.getElementById('tot').textContent=total;
 let cur=0,running=false,sec=0,it=null;
-function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>s.classList.toggle('on',x===i));cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1}
+function show(i){if(i<0||i>=total)return;slides.forEach((s,x)=>{s.classList.remove('on','prev');if(x===i)s.classList.add('on');else if(x<i)s.classList.add('prev')});cur=i;document.getElementById('cur').textContent=i+1;document.getElementById('pfill').style.width=((i+1)/total*100)+'%';document.getElementById('navL').disabled=i===0;document.getElementById('navR').disabled=i===total-1;document.getElementById('notes').innerHTML=slides[i].dataset.notes||''}
 document.getElementById('navL').onclick=()=>show(cur-1);document.getElementById('navR').onclick=()=>show(cur+1);
 document.getElementById('tBtn').onclick=()=>{if(running){clearInterval(it);running=false;document.getElementById('tBtn').textContent='▶'}else{it=setInterval(()=>{sec++;const m=String(Math.floor(sec/60)).padStart(2,'0'),s=String(sec%60).padStart(2,'0');document.getElementById('elapsed').textContent=m+':'+s},1000);running=true;document.getElementById('tBtn').textContent='■'}};
 document.getElementById('notesBtn').onclick=()=>{document.getElementById('notes').classList.toggle('on');document.getElementById('notesBtn').classList.toggle('on')};


### PR DESCRIPTION
## 概要
v3全8回の見た目をv2のデザイン（プレゼン級・大型フォント・グラデーション）に統一。

## 主な変更
- **フォントサイズ拡大**: h1 56px / h2 40px / h3 28px / p 24px / ul 22px
- **h1にグラデーション**: 青→紫
- **カード・ボックス大型化**: border-radius 16px / padding 22〜26px
- **プロンプトブロック**: 左に緑6pxボーダー、フォント20px
- **CTAボタン**: グラデーション＋ホバー時の浮き上がり
- **プログレスバー追加**: 画面下端、青→紫のグラデーション
- **nav矢印**: 52px円形、シャドウ付き
- **講師ノート**: backdrop-blur付き、より上品に

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uym14FX36mBZT9fh2KoSuf)_